### PR TITLE
chore: Update .gitignore to exclude database and study files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,14 @@ getting_started_django
 
 __pycache__
 
+
+# Actual quiz data file.
+# Managing this file leads to unintegrity of quiz data and model.
+db.sqlite3
+
+# Ignores gemini cli files
 *.skill
+.gemini
+
+# Getting started with new  technology
+study


### PR DESCRIPTION
This pull request updates `.gitignore` to:
- Exclude `db.sqlite3` to ensure data integrity.
- Ignore `.gemini` and `*.skill` files for Gemini CLI.
- Ignore the `study` directory for experimental learning code.