### PR TITLE
Docs: add issue and branching rule to GEMINI.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -52,6 +52,7 @@
 3. Access the mock API at `http://localhost:3000/quiz`
 
 ## Development Conventions
+- **Issue and Branching**: Before creating any branch, you MUST create an issue for the task you are handling. The branch name MUST include the issue number in the format `feature/<issue_number>-<short-descriptive-name>`.
 - **Data Integrity**: The `ChoiceQuiz` model includes validation to ensure correct answer counts do not exceed frequency.
 - **Naming**: Follow standard Django naming conventions for apps and models.
 - **Documentation**: Update `docs/` and `README.md` when architectural changes occur.


### PR DESCRIPTION
This PR officially adds the following development convention to `GEMINI.md`:

- **Issue and Branching**: Requires creating a GitHub issue before starting any new branch and specifies the branch naming format as `feature/<issue_number>-<short-descriptive-name>`.

Closes #12.